### PR TITLE
Add pip517 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "disspcap"
+version = "1.1.1"
+description = "Pcap parsing library."
+authors = ["Daniel Uhricek <daniel.uhricek@gypri.cz>"]
+license = "MIT"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+pybind11 = "^2.2"
+
+[build-system]
+requires = ["setuptools>=42", "wheel", "pybind11~=2.6.1"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,6 @@ class get_pybind_include(object):
     method can be invoked. """
 
     def __init__(self, user=False):
-        try:
-            import pybind11
-        except ImportError:
-            if subprocess.call([sys.executable, '-m', 'pip', 'install', 'pybind11']):
-                raise RuntimeError('pybind11 install failed.')
-
         self.user = user
 
     def __str__(self):


### PR DESCRIPTION
In order to install `disspcap` from other package management tools (e.g. `poetry`), we will need to have `pyproject.toml` for them to build the package.

This also ensure we have pybind11 during the compilation, so we don't need to install `pybind11` from `setup.py` anymore.

We can test this by `$python -m pip wheel --use-pep517 .`.